### PR TITLE
test: get promo post count integration test

### DIFF
--- a/src/test/java/com/project/be_java_hisp_w29_g10/Integratioon/controller/ProductControllerTest.java
+++ b/src/test/java/com/project/be_java_hisp_w29_g10/Integratioon/controller/ProductControllerTest.java
@@ -6,6 +6,7 @@ import com.project.be_java_hisp_w29_g10.dto.request.PostRequestDto;
 import com.project.be_java_hisp_w29_g10.dto.request.ProductRequestDto;
 import com.project.be_java_hisp_w29_g10.dto.response.PromoPostCountDto;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -63,6 +64,7 @@ class ProductControllerTest {
     }
 
     @Test
+    @DisplayName("IntegrationTest-011: Happy Path")
     void getPromoPostOkTest() throws Exception {
         MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/products/promo-post/count?user_id=1")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -77,6 +79,7 @@ class ProductControllerTest {
     }
 
     @Test
+    @DisplayName("IntegrationTest-011: Non Existing Seller")
     void getPromoPostNotFoundTest() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.get("/products/promo-post/count?user_id=100")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/project/be_java_hisp_w29_g10/Integratioon/controller/ProductControllerTest.java
+++ b/src/test/java/com/project/be_java_hisp_w29_g10/Integratioon/controller/ProductControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.project.be_java_hisp_w29_g10.dto.request.PostRequestDto;
 import com.project.be_java_hisp_w29_g10.dto.request.ProductRequestDto;
+import com.project.be_java_hisp_w29_g10.dto.response.PromoPostCountDto;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,11 +12,13 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import java.time.LocalDate;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -57,6 +60,28 @@ class ProductControllerTest {
                 ).andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.content().string("Publicación creada exitosamente."));
+    }
+
+    @Test
+    void getPromoPostOkTest() throws Exception {
+        MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/products/promo-post/count?user_id=1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                ).andDo(print())
+                .andExpect(status().isOk())
+                .andReturn();
+        PromoPostCountDto response = mapper.readValue(result.getResponse().getContentAsString(), PromoPostCountDto.class);
+        //assertions
+        assertEquals(1L, response.getUser_id());
+        assertEquals("Andrés", response.getUser_name());
+        assertEquals(2L, response.getPromo_products_count());
+    }
+
+    @Test
+    void getPromoPostNotFoundTest() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/products/promo-post/count?user_id=100")
+                        .contentType(MediaType.APPLICATION_JSON)
+                ).andDo(print())
+                .andExpect(status().isNotFound());
     }
 
 }


### PR DESCRIPTION
Agrega test de integración para la US-11 "Obtener la cantidad de productos en promoción de un determinado vendedor"

- Obtiene el numero de promociones con promo de un vendedor existente y valida que los campos de respuesta coincidan con los esperados
-  Realiza la petición con una Id de usuario no existente y espera un 404 NotFoun